### PR TITLE
Fix syntax warnings related to BPO-34850

### DIFF
--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -974,7 +974,7 @@ class Extractor(Module):
             
             # Fork a child process
             child_pid = os.fork()
-            if child_pid is 0:
+            if child_pid == 0:
                 # Switch to the run-as user privileges, if one has been set
                 if self.runas_uid is not None and self.runas_gid is not None:
                     os.setgid(self.runas_uid)
@@ -989,7 +989,7 @@ class Extractor(Module):
             rval = subprocess.call(shlex.split(command), stdout=tmp, stderr=tmp)
 
         # A true child process should exit with the subprocess exit value
-        if child_pid is 0:
+        if child_pid == 0:
             sys.exit(rval)
         # If no os.fork() happened, just return the subprocess exit value
         elif child_pid is None:


### PR DESCRIPTION
Since version 3.8, Python issues a syntax warning when comparing two numbers using identity operators, according to BPO-34850.

This caused following warnings to be displayed during install:

```
extractor.py:977: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
   if child_pid is 0:
extractor.py:992: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
   if child_pid is 0:
```
Issue description: https://bugs.python.org/issue34850
